### PR TITLE
fix: Enable jekyll-archives and jekyll-include-cache

### DIFF
--- a/my-blog/Gemfile
+++ b/my-blog/Gemfile
@@ -9,6 +9,9 @@ gem "jekyll-paginate", "~> 1.1.0"
 gem "jekyll-seo-tag", "~> 2.8.0"
 gem "jekyll-sitemap", "~> 1.4.0"
 gem "jekyll-remote-theme", "~> 0.4.3"
+gem "jekyll-compress-html", "~> 3.1.0" # For HTML compression
+gem "jekyll-archives", "~> 2.2.1"         # For category/tag archive pages (theme dependency)
+gem "jekyll-include-cache", "~> 0.2.1"  # For caching includes, performance
 
 # Other common Chirpy dependencies (optional, add if specific features are needed and cause errors)
 # gem "jekyll-moments", "~> 2.2.1" # For timeago functionality

--- a/my-blog/_config.yml
+++ b/my-blog/_config.yml
@@ -179,7 +179,7 @@ collections:
     output: true
     sort_by: order
   category_pages:
-    output: true
+    # output: true # Disabled to prefer jekyll-archives for /categories/ URLs
     permalink: /categories/:title/ # :title will be the filename (category_id)
 
 defaults:
@@ -214,9 +214,10 @@ plugins:
   - jekyll-paginate
   - jekyll-feed
   - jekyll-seo-tag
-  # - jekyll-archives
+  - jekyll-archives
   - jekyll-sitemap
   - jekyll-remote-theme
+  - jekyll-include-cache
 
 sass:
   style: compressed
@@ -246,11 +247,11 @@ exclude:
   - vendor
   - .travis.yml
 
-#jekyll-archives:
-#  enabled: [categories, tags]
-#  layouts:
-#    category: category
-#    tag: tag
-#  permalinks:
-#    tag: /tags/:name/
-#    category: /categories/:name/
+jekyll-archives:
+  enabled: [categories, tags]
+  layouts:
+    category: category # This should match the layout file name in _layouts
+    tag: tag # This should match the layout file name in _layouts
+  permalinks:
+    tag: /tags/:name/
+    category: /categories/:name/ # This will conflict with our custom collection if not handled


### PR DESCRIPTION
- Adds jekyll-archives and jekyll-include-cache to Gemfile.
- Enables jekyll-archives in _config.yml plugins and uncomments its configuration block. This allows the theme to use its default mechanism for category/tag archive pages.
- Adds jekyll-include-cache to _config.yml plugins.
- Comments out 'output: true' for the custom 'category_pages' collection to prevent permalink conflicts with jekyll-archives, prioritizing the theme's default archive generation.

You should run 'bundle install' after pulling these changes.

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

## Additional context
<!-- e.g. Fixes #(issue) -->
